### PR TITLE
Switching `sandbox` for faster CI

### DIFF
--- a/.github/workflows/awe-swapper-build-test.yaml
+++ b/.github/workflows/awe-swapper-build-test.yaml
@@ -36,14 +36,8 @@ jobs:
       with:
         extra_args: --all-files --show-diff-on-failure
 
-    - name: Clone algorand sanbox
-      run: cd .. && git clone https://github.com/algorand/sandbox.git
-      if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[pytest]')
-
-    - name: Run algorand sandbox
-      shell: 'script -q -e -c "bash {0}"' # hacky hack to make TTY work
-      run: cd ../sandbox && ./sandbox up dev
-      if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[pytest]')
+    - name: Run Algorand sandbox
+      run: docker run -d -p 4001:4001 -p 4002:4002 makerxau/algorand-sandbox-dev
 
     - name: Delay before testing
       run: sleep 60


### PR DESCRIPTION
### Description

> _Please explain the changes you made here_

Switching from [original Algorand `sandbox`](https://github.com/algorand/sandbox) cloning to [MakerXStudio Dev `sandbox`](https://github.com/MakerXStudio/algorand-sandbox-dev) directly on Docker Hub, avoiding `sandbox` building from scratch every time.

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
