### PR TITLE
refactor: add ability to display active swaps not present in config json

### DIFF
--- a/src/components/Dialogs/AboutDialog.tsx
+++ b/src/components/Dialogs/AboutDialog.tsx
@@ -55,7 +55,7 @@ export default function AboutDialog({ open, changeState }: Props) {
         <DialogContent dividers={true}>
           <DialogContentText ref={descriptionElementRef} tabIndex={-1}>
             {`AlgoWorld Swapper is a free and open-source tool for swapping assets on Algorand blockchain. Distributed under GPLv3 license.
-            Swaps are powered by Algorand Smart Signatures and were developed in collaboration with a Solution Architect from Algorand (credits: @cusma). AlgoWorld currently charges 0.5 Algo fee per swap, the fee is then periodically transfered to AWT/ALGO pair on Tinyman to increase liquidity for AlgoWorld Token.`}
+            Swaps are powered by Algorand Smart Signatures and were developed in collaboration with a Solution Architect from Algorand (credits: @cusma). AlgoWorld currently charges 0.05 Algo fee per swap, the fee is then periodically transfered to AWT/ALGO pair on Tinyman to increase liquidity for AlgoWorld Token.`}
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/utils/api/accounts/optAssetsForAccount.ts
+++ b/src/utils/api/accounts/optAssetsForAccount.ts
@@ -59,7 +59,7 @@ export default async function optAssetsForAccount(
           assetIndex: index,
           note: new Uint8Array(
             Buffer.from(
-              ` I am an asset opt-${optPrefix} transaction for algoworld swapper escrow, thank you for using AlgoWorld Swapper (☞ ͡° ͜ʖ ͡°)☞`,
+              ` I am an asset opt-${optPrefix} transaction for algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
             ),
           ),
           closeRemainderTo: deOptIn ? creatorAddress : undefined,

--- a/src/utils/api/accounts/recoverSwapConfigurationsForAccount.ts
+++ b/src/utils/api/accounts/recoverSwapConfigurationsForAccount.ts
@@ -1,0 +1,58 @@
+/**
+ * AlgoWorld Swapper
+ * Copyright (C) 2022 AlgoWorld
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { LATEST_SWAP_PROXY_VERSION } from '@/common/constants';
+import { ChainType } from '@/models/Chain';
+import { IpfsGateway } from '@/models/Gateway';
+import { SwapConfiguration } from '@/models/Swap';
+import filterAsync from '@/utils/filterAsync';
+import getLogicSign from '../accounts/getLogicSignature';
+import getCompiledProxy from '../swaps/getCompiledProxy';
+import loadSwapConfigurations from '../swaps/loadSwapConfigurations';
+import accountExists from './accountExists';
+
+export default async function recoverSwapConfigurationsForAccount(
+  chain: ChainType,
+  gateway: IpfsGateway,
+  address: string,
+) {
+  const compiledSwapProxy = await getCompiledProxy({
+    swap_creator: address,
+    version: LATEST_SWAP_PROXY_VERSION,
+    chain_type: chain,
+  });
+  const data = await compiledSwapProxy.data;
+  const proxyLsig = getLogicSign(data[`result`]);
+  const proxyAddress = proxyLsig.address();
+
+  const response = await loadSwapConfigurations(
+    chain,
+    gateway,
+    proxyAddress,
+    true,
+  );
+
+  const activeSwapConfigurations = await filterAsync(
+    response,
+    async (swapConfiguration: SwapConfiguration) => {
+      return accountExists(chain, swapConfiguration.escrow);
+    },
+  );
+
+  return activeSwapConfigurations;
+}

--- a/src/utils/api/swaps/createInitSwapTxns.ts
+++ b/src/utils/api/swaps/createInitSwapTxns.ts
@@ -41,7 +41,7 @@ export default async function createInitSwapTxns(
       amount: fundingFee,
       note: new Uint8Array(
         Buffer.from(
-          `I am a fee transaction for configuring algoworld swapper escrow, thank you for using AlgoWorld Swapper :-)`,
+          `I am a fee transaction for configuring algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
         ),
       ),
       suggestedParams,
@@ -61,7 +61,7 @@ export default async function createInitSwapTxns(
         assetIndex: Number(asset.index),
         note: new Uint8Array(
           Buffer.from(
-            ` I am an asset opt-in transaction for algoworld swapper escrow, thank you for using AlgoWorld Swapper (☞ ͡° ͜ʖ ͡°)☞`,
+            ` I am an asset opt-in transaction for algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
           ),
         ),
         suggestedParams,

--- a/src/utils/api/swaps/createPerformSwapTxns.ts
+++ b/src/utils/api/swaps/createPerformSwapTxns.ts
@@ -36,7 +36,7 @@ async function createAsaToAsaSwapPerformTxns(
 ) {
   const suggestedParams = await getTransactionParams(chain);
 
-  const note = `I am a asset transfer transaction to perform swap. thank you for using AlgoWorld Swapper! :-)`;
+  const note = `I am a asset transfer transaction to perform swap. thank you for using AlgoWorld Swapper! 🙂`;
 
   const txns = [];
 
@@ -96,7 +96,7 @@ async function createAsasToAlgoSwapPerformTxns(
 ) {
   const suggestedParams = await getTransactionParams(chain);
 
-  const note = `I am a asset transfer transaction to perform swap. thank you for using AlgoWorld Swapper! :-)`;
+  const note = `I am a asset transfer transaction to perform swap. thank you for using AlgoWorld Swapper! 🙂`;
   const txns = [];
 
   const incentiveFeeTxn = createTransactionToSign(

--- a/src/utils/api/swaps/createSaveSwapConfigTxns.ts
+++ b/src/utils/api/swaps/createSaveSwapConfigTxns.ts
@@ -37,7 +37,7 @@ export default async function createSaveSwapConfigTxns(
     amount: fundingFee,
     note: new Uint8Array(
       Buffer.from(
-        `I am a fee transaction for configuring algoworld swapper proxy, thank you for using AlgoWorld Swapper :-)`,
+        `I am a fee transaction for configuring algoworld swapper proxy, thank you for using AlgoWorld Swapper 🙂`,
       ),
     ),
     suggestedParams,

--- a/src/utils/api/swaps/createSwapDeactivateTxns.ts
+++ b/src/utils/api/swaps/createSwapDeactivateTxns.ts
@@ -43,7 +43,7 @@ export default async function createSwapDeactivateTxns(
         closeRemainderTo: creatorAddress,
         note: new Uint8Array(
           Buffer.from(
-            `I am a fee transaction for closing algoworld swapper escrow, thank you for using AlgoWorld Swapper :-)`,
+            `I am a fee transaction for closing algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
           ),
         ),
         suggestedParams,
@@ -62,7 +62,7 @@ export default async function createSwapDeactivateTxns(
       closeRemainderTo: creatorAddress,
       note: new Uint8Array(
         Buffer.from(
-          `Transaction for the closing algoworld swapper escrow, thank you for using AlgoWorld Swapper :-)`,
+          `Transaction for the closing algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
         ),
       ),
       suggestedParams,
@@ -79,7 +79,7 @@ export default async function createSwapDeactivateTxns(
       amount: 0,
       note: new Uint8Array(
         Buffer.from(
-          `Transaction for the closing algoworld swapper escrow, thank you for using AlgoWorld Swapper :-)`,
+          `Transaction for the closing algoworld swapper escrow, thank you for using AlgoWorld Swapper 🙂`,
         ),
       ),
       suggestedParams,

--- a/src/utils/api/swaps/createSwapDepositTxns.ts
+++ b/src/utils/api/swaps/createSwapDepositTxns.ts
@@ -49,7 +49,7 @@ export default async function createSwapDepositTxns(
         amount: Math.abs(fundingFee - escrowBalance),
         note: new Uint8Array(
           Buffer.from(
-            `I am a fee transaction for configuring algoworld swapper escrow min balance, thank you for using AlgoWorld Swapper :-)`,
+            `I am a fee transaction for configuring algoworld swapper escrow min balance, thank you for using AlgoWorld Swapper 🙂`,
           ),
         ),
         suggestedParams,
@@ -71,7 +71,7 @@ export default async function createSwapDepositTxns(
           Buffer.from(
             `Transaction for the depositing asset ${
               asset.index
-            } to swapper ${escrow.address()}, thank you for using AlgoWorld Swapper :-)`,
+            } to swapper ${escrow.address()}, thank you for using AlgoWorld Swapper 🙂`,
           ),
         ),
         suggestedParams,


### PR DESCRIPTION
Work in progress. 

Based on user report bug - latency in ipfs file upload can cause cases when swaps are not persisted in configuration file and are not propagated via pay txn note on users proxy address. Current aid is to add an option fetching all active swaps created which arent visible on swap configuration file